### PR TITLE
Keep anisotropic U positive-definite via Cholesky parametrization

### DIFF
--- a/tests/unit/model/test_parameter_wrappers.py
+++ b/tests/unit/model/test_parameter_wrappers.py
@@ -336,3 +336,102 @@ class TestPositiveMixedTensor:
         # After set(), output should be close to 100.0
         result = t()
         assert torch.allclose(result[0], torch.tensor(100.0), rtol=0.01)
+
+
+def _u6_matrix(u6):
+    """(...,6) [u11,u22,u33,u12,u13,u23] -> symmetric (...,3,3)."""
+    import torch as _t
+
+    M = _t.zeros(*u6.shape[:-1], 3, 3, dtype=u6.dtype)
+    M[..., 0, 0], M[..., 1, 1], M[..., 2, 2] = u6[..., 0], u6[..., 1], u6[..., 2]
+    M[..., 0, 1] = M[..., 1, 0] = u6[..., 3]
+    M[..., 0, 2] = M[..., 2, 0] = u6[..., 4]
+    M[..., 1, 2] = M[..., 2, 1] = u6[..., 5]
+    return M
+
+
+class TestCholeskyMixedTensor:
+    """Tests for CholeskyMixedTensor (anisotropic U kept positive-definite)."""
+
+    @pytest.mark.unit
+    def test_roundtrip_preserves_pd_u(self):
+        """A positive-definite U should round-trip through the Cholesky form."""
+        from torchref.model.parameter_wrappers import CholeskyMixedTensor
+
+        U = torch.tensor(
+            [
+                [0.2319, 0.1627, 0.1717, -0.0464, 0.0254, -0.0834],
+                [0.30, 0.28, 0.25, 0.05, -0.02, 0.01],
+            ],
+            dtype=torch.float64,
+        )
+        out = CholeskyMixedTensor(U)().detach()
+        assert torch.allclose(out, U, atol=1e-6)
+
+    @pytest.mark.unit
+    def test_output_is_positive_definite_for_arbitrary_params(self):
+        """For ANY internal parameters, the reconstructed U must be PD."""
+        from torchref.model.parameter_wrappers import CholeskyMixedTensor
+
+        U = torch.tensor([[0.2, 0.2, 0.2, 0.0, 0.0, 0.0]], dtype=torch.float64)
+        t = CholeskyMixedTensor(U)
+        # Shove the raw Cholesky params to extreme/negative values (what an LBFGS
+        # line-search trial step would do); U must remain positive-definite.
+        with torch.no_grad():
+            t.refinable_params.copy_(
+                torch.tensor(
+                    [[-8.0, 5.0, -3.0, -50.0, 40.0, -30.0]], dtype=torch.float64
+                )
+            )
+        eigs = torch.linalg.eigvalsh(_u6_matrix(t().detach()))
+        assert torch.all(eigs > 0), eigs
+        assert torch.isfinite(t()).all()
+
+    @pytest.mark.unit
+    def test_nan_rows_pass_through(self):
+        """Isotropic atoms carry U = NaN; those rows must stay NaN, not error."""
+        from torchref.model.parameter_wrappers import CholeskyMixedTensor
+
+        U = torch.tensor(
+            [[0.2, 0.2, 0.2, 0.0, 0.0, 0.0], [float("nan")] * 6],
+            dtype=torch.float64,
+        )
+        out = CholeskyMixedTensor(U)().detach()
+        assert torch.isnan(out[1]).all()
+        assert torch.isfinite(out[0]).all()
+
+    @pytest.mark.unit
+    def test_update_refinable_mask_no_double_transform(self):
+        """Repartitioning must not double-apply the Cholesky transform."""
+        from torchref.model.parameter_wrappers import CholeskyMixedTensor
+
+        U = torch.tensor(
+            [[0.2319, 0.1627, 0.1717, -0.0464, 0.0254, -0.0834]] * 3,
+            dtype=torch.float64,
+        )
+        t = CholeskyMixedTensor(U)
+        before = t().detach().clone()
+        t.update_refinable_mask(torch.tensor([True, False, True]))
+        assert torch.allclose(t().detach(), before, atol=1e-6)
+
+    @pytest.mark.unit
+    def test_copy_preserves_type_and_values(self):
+        """copy() must stay a CholeskyMixedTensor with identical output."""
+        from torchref.model.parameter_wrappers import CholeskyMixedTensor
+
+        U = torch.tensor([[0.25, 0.22, 0.20, 0.03, -0.01, 0.02]], dtype=torch.float64)
+        t = CholeskyMixedTensor(U)
+        c = t.copy()
+        assert isinstance(c, CholeskyMixedTensor)
+        assert torch.allclose(c().detach(), t().detach(), atol=1e-6)
+
+    @pytest.mark.unit
+    def test_gradient_flows_to_refinable_params(self):
+        """forward() must be differentiable wrt the internal Cholesky params."""
+        from torchref.model.parameter_wrappers import CholeskyMixedTensor
+
+        U = torch.tensor([[0.25, 0.22, 0.20, 0.03, -0.01, 0.02]], dtype=torch.float64)
+        t = CholeskyMixedTensor(U)
+        t().sum().backward()
+        assert t.refinable_params.grad is not None
+        assert torch.isfinite(t.refinable_params.grad).all()

--- a/torchref/model/model.py
+++ b/torchref/model/model.py
@@ -23,6 +23,7 @@ from torchref.config import get_default_device, get_float_dtype
 from torchref.io import cif, pdb
 from torchref.base import math_torch
 from torchref.model.parameter_wrappers import (
+    CholeskyMixedTensor,
     MixedTensor,
     OccupancyTensor,
     PositiveMixedTensor,
@@ -699,7 +700,11 @@ class Model(DeviceMovementMixin, DebugMixin, nn.Module):
             name="adp",
             device=self.device,
         )
-        self.u = MixedTensor(
+        # Cholesky parametrization keeps the anisotropic U positive-definite by
+        # construction (U = L Lᵀ), so refinement can't drive it indefinite and
+        # blow up the structure-factor FFT. Anisotropic analogue of the
+        # PositiveMixedTensor used for the isotropic B above.
+        self.u = CholeskyMixedTensor(
             torch.tensor(
                 self.pdb[["u11", "u22", "u33", "u12", "u13", "u23"]].values,
                 dtype=self.dtype_float,

--- a/torchref/model/parameter_wrappers.py
+++ b/torchref/model/parameter_wrappers.py
@@ -1252,6 +1252,185 @@ class PositiveMixedTensor(MixedTensor):
         )
 
 
+class CholeskyMixedTensor(MixedTensor):
+    """A MixedTensor for anisotropic ADPs (U tensors) kept positive-definite.
+
+    The six U components (u11, u22, u33, u12, u13, u23) are stored internally as
+    the six free parameters of a lower-triangular Cholesky factor ``L``, and the
+    public tensor is reconstructed as ``U = L Lᵀ``. With the diagonal of ``L``
+    mapped through ``exp(x) + epsilon`` (strictly positive), ``U`` is positive-
+    definite by construction for *any* value of the free parameters -- so
+    unconstrained optimisation (e.g. LBFGS line search) can never drive ``U``
+    indefinite. An indefinite ``U`` otherwise makes the per-atom anisotropic
+    B-matrix singular, so its inverse and the Gaussian exponent blow up and the
+    structure-factor FFT returns NaN. This is the anisotropic analogue of
+    :class:`PositiveMixedTensor`, which keeps isotropic B positive the same way.
+
+    Rows that are entirely non-finite (isotropic atoms carry ``U = NaN``) are
+    passed through unchanged in both directions, preserving the iso/aniso split.
+
+    Notes
+    -----
+    The eigen-decomposition / Cholesky needed to map ``U -> L`` runs only at
+    construction and on freeze/unfreeze; the forward (hot) path is just ``exp``
+    and a handful of products, so gradients flow cleanly to ``refinable_params``
+    with no matrix factorisation in the autograd graph.
+    """
+
+    def __init__(
+        self,
+        initial_values: torch.Tensor = None,
+        refinable_mask: Optional[torch.Tensor] = None,
+        requires_grad: bool = True,
+        dtype: Optional[torch.dtype] = None,
+        device: Optional[torch.device] = None,
+        name: Optional[str] = None,
+        epsilon: float = 1e-3,
+    ):
+        self.epsilon = epsilon
+        if initial_values is None:
+            super().__init__(None, refinable_mask, requires_grad, dtype, device, name)
+            return
+        raw = self._u6_to_raw6(initial_values)
+        super().__init__(
+            initial_values=raw,
+            refinable_mask=refinable_mask,
+            requires_grad=requires_grad,
+            dtype=dtype,
+            device=device,
+            name=name,
+        )
+
+    # ------------------------------------------------------------------
+    # U (6-vector) <-> Cholesky free-parameter (6-vector) transforms.
+    # Both operate on (..., 6) tensors and pass NaN rows through untouched.
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _u6_to_matrix(U: torch.Tensor) -> torch.Tensor:
+        M = U.new_zeros(*U.shape[:-1], 3, 3)
+        M[..., 0, 0] = U[..., 0]
+        M[..., 1, 1] = U[..., 1]
+        M[..., 2, 2] = U[..., 2]
+        M[..., 0, 1] = M[..., 1, 0] = U[..., 3]
+        M[..., 0, 2] = M[..., 2, 0] = U[..., 4]
+        M[..., 1, 2] = M[..., 2, 1] = U[..., 5]
+        return M
+
+    def _u6_to_raw6(self, U: torch.Tensor) -> torch.Tensor:
+        """U components -> Cholesky free parameters [log(L_ii - eps); L_offdiag]."""
+        eps = self.epsilon
+        finite = torch.isfinite(U).all(dim=-1)
+        M = self._u6_to_matrix(torch.nan_to_num(U, nan=0.0))
+        eye = torch.eye(3, dtype=M.dtype, device=M.device).expand_as(M)
+        M = torch.where(finite[..., None, None], M, eye)
+        # Project to positive-definite: symmetrise, clamp eigenvalues off zero.
+        # No-op for well-conditioned deposited U; rescues marginally non-PD input.
+        M = 0.5 * (M + M.transpose(-1, -2))
+        w, V = torch.linalg.eigh(M)
+        w = w.clamp(min=eps * eps)
+        M = (V * w.unsqueeze(-2)) @ V.transpose(-1, -2)
+        L = torch.linalg.cholesky(M)
+        diag = torch.stack([L[..., 0, 0], L[..., 1, 1], L[..., 2, 2]], dim=-1)
+        off = torch.stack([L[..., 1, 0], L[..., 2, 0], L[..., 2, 1]], dim=-1)
+        raw_diag = torch.log((diag - eps).clamp(min=1e-12))  # invert exp(x)+eps
+        raw = torch.cat([raw_diag, off], dim=-1)
+        nan = torch.full_like(raw, float("nan"))
+        return torch.where(finite.unsqueeze(-1), raw, nan)
+
+    def _raw6_to_u6(self, raw: torch.Tensor) -> torch.Tensor:
+        """Cholesky free parameters -> U components (U = L Lᵀ). PD by construction."""
+        eps = self.epsilon
+        diag, off = raw[..., :3], raw[..., 3:]
+        L11 = torch.exp(diag[..., 0]) + eps
+        L22 = torch.exp(diag[..., 1]) + eps
+        L33 = torch.exp(diag[..., 2]) + eps
+        L21, L31, L32 = off[..., 0], off[..., 1], off[..., 2]
+        U11 = L11 * L11
+        U22 = L21 * L21 + L22 * L22
+        U33 = L31 * L31 + L32 * L32 + L33 * L33
+        U12 = L21 * L11
+        U13 = L31 * L11
+        U23 = L31 * L21 + L32 * L22
+        return torch.stack([U11, U22, U33, U12, U13, U23], dim=-1)
+
+    def forward(self) -> torch.Tensor:
+        """Return the full U tensor (positive-definite per finite row)."""
+        return self._raw6_to_u6(super().forward())
+
+    def _set_values(self, key, value: torch.Tensor) -> None:
+        """Set U-space values at ``key``; stored internally as Cholesky params."""
+        current = self.forward().detach()
+        current[key] = value
+        raw = self._u6_to_raw6(current)
+        self.fixed_values = raw.clone()
+        if self.refinable_mask.any():
+            self.refinable_params = nn.Parameter(
+                raw[self.refinable_mask].clone(),
+                requires_grad=self.refinable_params.requires_grad,
+            )
+
+    def fix(self, mask: torch.Tensor, freeze_at_current: bool = True):
+        """Freeze rows, storing their current value in Cholesky space."""
+        if freeze_at_current:
+            with torch.no_grad():
+                raw = self._u6_to_raw6(self.forward())
+            self.fixed_values[mask] = raw[mask]
+        super().fix(mask, freeze_at_current=False)
+
+    def refine(self, mask: torch.Tensor):
+        """Make rows refinable, preserving their current value in Cholesky space."""
+        with torch.no_grad():
+            raw = self._u6_to_raw6(self.forward())
+        self.fixed_values[mask] = raw[mask]
+        super().refine(mask)
+
+    def set(self, values: torch.Tensor, mask: torch.Tensor) -> None:
+        """Set U-space values for masked rows (converted to Cholesky internally)."""
+        self._set_values(mask, values)
+
+    def update_refinable_mask(
+        self, new_mask: torch.Tensor, reset_refinable: bool = False
+    ):
+        """Repartition refinable/fixed elements, preserving values in U space.
+
+        The base implementation re-stores ``forward()`` output directly, which
+        would double-transform here (U written back into Cholesky-parameter
+        storage); convert to Cholesky parameters first, mirroring
+        :meth:`PositiveMixedTensor.update_refinable_mask`.
+        """
+        if new_mask.shape[0] != self.shape[0]:
+            raise ValueError(
+                f"new_mask shape {new_mask.shape} must match tensor shape {self.shape}"
+            )
+        with torch.no_grad():
+            current_raw = self._u6_to_raw6(self.forward())
+        self.refinable_mask = new_mask.to(device=self.device)
+        self.fixed_mask = ~new_mask
+        self.fixed_values = current_raw.clone()
+        new_refinable = current_raw[self.refinable_mask].clone()
+        self.refinable_params = nn.Parameter(
+            new_refinable, requires_grad=self.refinable_params.requires_grad
+        )
+        self._build_index_cache()
+
+    def copy(self) -> "CholeskyMixedTensor":
+        """Deep-copy, preserving the Cholesky parametrization.
+
+        Rebuilds from the U-space values (``__init__`` reconverts to Cholesky
+        parameters), so the copy stays positive-definite rather than degrading
+        to a plain unconstrained :class:`MixedTensor`.
+        """
+        return CholeskyMixedTensor(
+            initial_values=self.forward().detach(),
+            refinable_mask=self.refinable_mask.clone(),
+            requires_grad=self.refinable_params.requires_grad,
+            dtype=self.dtype,
+            device=self.device,
+            name=self._name,
+            epsilon=self.epsilon,
+        )
+
+
 class OccupancyTensor(MixedTensor):
     """
     A specialized MixedTensor for handling occupancy parameters in crystallographic refinement.


### PR DESCRIPTION
## Problem

`refine_adp` (B-factor / ADP refinement) intermittently floods the log with `NON-FINITE LOSS DETECTED` and the x-ray loss goes NaN. The cause is **not** the x-ray target — all target modes (`gaussian`/`ls`/`ml`/`bhattacharyya`) hit it, because it originates upstream in the structure factor.

Anisotropic ADPs (`Model.u`) are stored in a plain, unconstrained `MixedTensor`, so an LBFGS line-search trial step can drive the `U` tensor **indefinite**. In the density kernel (`vectorized_add_to_map_aniso`), the per-(atom, Gaussian) anisotropic B-matrix `(B_itc92·I + 8π²·U)/4` then goes singular: `torch.linalg.inv` blows up and the Gaussian exponent `exp(−π²·rᵀB⁻¹r)` overflows to `+inf`, so the FFT returns an all-NaN structure factor. (The isotropic path is immune because `B` already uses `PositiveMixedTensor`, which keeps it positive by construction.)

## Fix

Add `CholeskyMixedTensor`: the six `U` components are stored internally as the free parameters of a lower-triangular Cholesky factor `L` (diagonal mapped through `exp(x)+ε`, strictly positive), and `U = L Lᵀ` is reconstructed in `forward()`. `U` is then **positive-definite for any parameter values**, so the composed B-matrix is always PD and the kernel's inverse/determinant stay finite — no clamp or eigen-projection needed. This is the anisotropic analogue of `PositiveMixedTensor` (isotropic B), and switches `Model.u` to use it.

- Isotropic atoms (`U = NaN`) pass through untouched, preserving the iso/aniso split.
- The `eigh`/`cholesky` run only at construction and on freeze/unfreeze; the forward hot path is just `exp` + products, so gradients flow cleanly with **no matrix factorisation in the autograd graph**.

## Validation

- On a sulfur-anomalous test refinement, `refine_adp` goes from ~78 non-finite-loss events to **0**, with `U` staying positive-definite (min eigenvalue ~0.04 after refinement) and R-factors unchanged at the scaling-only start.
- New unit tests cover: round-trip of a PD `U`, positive-definiteness under extreme/negative internal params, NaN pass-through, no double-transform on `update_refinable_mask`, `copy()` type/value preservation, and gradient flow.
- Full suite (excl. GPU): 752 passed, 43 skipped (env-only), 0 failures.

## Caveat / follow-up

**`state_dict` migration**: the wrapper now stores Cholesky parameters rather than raw `U`, so models saved before this change won't load straight into the new `Model.u`. No migration shim is included here — flagging so it's a conscious decision before this reaches anyone with saved checkpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)